### PR TITLE
Update log4j 2.17.0 to 2.17.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,13 +40,13 @@
 		<dependency>
 			<artifactId>log4j-core</artifactId>
 			<groupId>org.apache.logging.log4j</groupId>
-			<version>2.12.1</version>
+			<version>2.17.1</version>
 		</dependency>
 
 		<dependency>
 			<artifactId>log4j-api</artifactId>
 			<groupId>org.apache.logging.log4j</groupId>
-			<version>2.12.1</version>
+			<version>2.17.1</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
Please refer to these articles :


- https://checkmarx.com/blog/cve-2021-44832-apache-log4j-2-17-0-arbitrary-code-execution-via-jdbcappender-datasource-element/
- https://logging.apache.org/log4j/2.x/